### PR TITLE
Item-Link-Feature

### DIFF
--- a/data/model.py
+++ b/data/model.py
@@ -118,7 +118,7 @@ class Model(Listener):
             item.name = item_info['name']
             item.icon = item_info['icon']
             item.rarity = item_info['rarity']
-
+            item.wiki = f'https://wiki.guildwars2.com/wiki/{item_info['name'].replace(" ", "_")}'
             if item_info['type'] not in ['Armor', 'Back', 'Gathering', 'Tool', 'Trinket', 'Weapon', 'Bag', 'Container',
                                          'Gizmo']:
                 item.stackable = True

--- a/ui/item_name_label.py
+++ b/ui/item_name_label.py
@@ -17,5 +17,6 @@ item_rarity_colors = {
 def item_name_label_ui(item: Item) -> None:
     color = item_rarity_colors.get(item.rarity, '#000000')
 
-    ui.label(item.name).style(
+    ui.link(item.name,item.wiki,new_tab=True).style(
         f'color: {color}; font-weight: bold')
+


### PR DESCRIPTION
Changed the item from a ui.label to ui.link which opens the item on the GW2 wiki.  Retained rarirty color for link 